### PR TITLE
fix for table names containing space on the end

### DIFF
--- a/src/Mousavi.Extensions.Configuration.SqlServer/SqlServerConfigurationProvider.cs
+++ b/src/Mousavi.Extensions.Configuration.SqlServer/SqlServerConfigurationProvider.cs
@@ -15,7 +15,7 @@ namespace Mousavi.Extensions.Configuration.SqlServer
         public SqlServerConfigurationProvider(SqlServerConfigurationSource source)
         {
             _source = source;
-            _query =$"select {_source.KeyColumn}, {_source.ValueColumn} from {_source.Schema}.{_source.Table}";
+            _query =$"select {_source.KeyColumn}, {_source.ValueColumn} from {_source.Schema}.[{_source.Table}]";
 
             if (_source.SqlServerWatcher != null)
             {


### PR DESCRIPTION
this isn't a breaking change, but I have two systems (legacy) which have space at the end of table names.
This will allow such scenario